### PR TITLE
Add "avoid overlay" option to generation captioned 

### DIFF
--- a/pynter/pynter.py
+++ b/pynter/pynter.py
@@ -19,6 +19,11 @@ class TextAlign(str, Enum):
     CENTER = 'center',
 
 
+class ImageMode(str, Enum):
+    OVERLAY = 'overlay',
+    NOT_OVERLAY = 'not_overlay',
+
+
 def split_text_on_width_size(text: str, max_width: float, fn_text_to_width: Callable) -> str:
     """
     Split a text given a maximum width
@@ -41,8 +46,10 @@ def split_text_on_width_size(text: str, max_width: float, fn_text_to_width: Call
     return "\n".join(text_pieces)
 
 
-def generate_captioned(text: str, image_path, size: Optional[Tuple[int, int]] = None, font_path: str = None,
+def generate_captioned(text: str, image_path, size: Optional[Tuple[int, int]] = None, image_mode=ImageMode.OVERLAY,
+                       font_path: str = None,
                        text_align: TextAlign = TextAlign.LEFT,
+                       text_min_height: Optional[float] = None,
                        bottom_margin: Optional[float] = 0.07, top_margin: Optional[float] = None,
                        left_margin: float = 0.2, right_margin: float = 0.2,
                        character_ratio: float = 0.07,
@@ -57,8 +64,10 @@ def generate_captioned(text: str, image_path, size: Optional[Tuple[int, int]] = 
     :param text: the text
     :param image_path: image path
     :param size: image tuple, if None size of the image_path are taken
+    :param image_mode: OVERLAY (text and background cover the image) or NOT_OVERLAY
     :param font_path: font path
     :param text_align: text alignment
+    :param text_min_height: minimum text height percentage (of total image height)
     :param bottom_margin: text bottom margin percentage
     :param top_margin: text top margin percentage
     :param left_margin: text left margin percentage
@@ -76,12 +85,38 @@ def generate_captioned(text: str, image_path, size: Optional[Tuple[int, int]] = 
     post_im = Image.open(image_path).convert('RGBA')
     W, H = size if size else post_im.size
     im = Image.new(mode='RGBA', size=(W, H))
+    # Compute text size and position
+    font = ImageFont.truetype(font_path, round(W * character_ratio))
+    draw = ImageDraw.Draw(im)
+    text = split_text_on_width_size(text, W - left_margin * W - right_margin * W,
+                                    lambda x: draw.multiline_textsize(x, font=font)[0])
+    w, h = draw.multiline_textsize(text, font=font)
+    if text_min_height and h < text_min_height*H:
+        h = text_min_height*H
+    # Calculate text background dimension
+    text_background_width = W
+    if text_background_mode in (TextBackgroundMode.ATTACH_TO_BOTTOM, TextBackgroundMode.ATTACH_TO_TOP):
+        text_background_height = h + H * bottom_margin * 2 if bottom_margin else h + H * top_margin * 2
+    else:
+        text_background_height = h + h * text_background_padding * 2
+    # Adapt and paste provided image
     post_img_w, post_img_h = post_im.size
-    resize_ratio = math.ceil(max(W / post_img_w, H / post_img_h))
-    post_img_w, post_img_h = post_img_w * resize_ratio, post_img_h * resize_ratio
+    img_height = H - text_background_height if image_mode == ImageMode.NOT_OVERLAY else H
+    resize_ratio = max(W / post_img_w, img_height / post_img_h)
+    post_img_w, post_img_h = math.ceil(post_img_w * resize_ratio), math.ceil(post_img_h * resize_ratio)
     post_im = post_im.resize((post_img_w, post_img_h), Image.ANTIALIAS)
-    offset = (round((W - post_img_w) / 2), round((H - post_img_h) / 2))
-    im.paste(post_im, offset)
+    if text_background_mode != TextBackgroundMode.ATTACH_TO_BOTTOM \
+            and text_background_mode != TextBackgroundMode.ATTACH_TO_TOP\
+            and image_mode.NOT_OVERLAY:
+        raise ValueError("NOT_OVERLAY option only supported with ATTACH_TO_TOP ot ATTACH_TO_BOTTOM")
+    offset_x = round((W - post_img_w) / 2)
+    if text_background_mode == TextBackgroundMode.ATTACH_TO_TOP and image_mode == ImageMode.NOT_OVERLAY:
+        offset_y = round((H - post_img_h) / 2 + text_background_height/2)
+    elif text_background_mode == TextBackgroundMode.ATTACH_TO_BOTTOM and image_mode == ImageMode.NOT_OVERLAY:
+        offset_y = round((H - post_img_h) / 2 - text_background_height/2)
+    else:
+        offset_y = round((H - post_img_h) / 2)
+    im.paste(post_im, (offset_x, offset_y))
     # Add Color Filter
     if filter_color:
         filter_im = Image.new(mode='RGBA', size=(W, H), color=filter_color)
@@ -90,11 +125,6 @@ def generate_captioned(text: str, image_path, size: Optional[Tuple[int, int]] = 
     for f in filters:
         im = im.filter(f)
     # Write Text
-    font = ImageFont.truetype(font_path, round(W * character_ratio))
-    draw = ImageDraw.Draw(im)
-    text = split_text_on_width_size(text, W - left_margin * W - right_margin * W,
-                                    lambda x: draw.multiline_textsize(x, font=font)[0])
-    w, h = draw.multiline_textsize(text, font=font)
     if bottom_margin and top_margin or (not bottom_margin and not top_margin):
         raise ValueError("Provide either bottom or top margin")
     if bottom_margin:
@@ -103,12 +133,6 @@ def generate_captioned(text: str, image_path, size: Optional[Tuple[int, int]] = 
         text_w_anchor, text_h_anchor = W * left_margin, H * top_margin
     # Write text background
     if not text_background_mode == TextBackgroundMode.NONE:
-        text_background_width = W
-        if text_background_mode == TextBackgroundMode.ATTACH_TO_BOTTOM or \
-                text_background_mode == TextBackgroundMode.ATTACH_TO_TOP:
-            text_background_height = h + H * bottom_margin * 2 if bottom_margin else h + H * top_margin * 2
-        else:
-            text_background_height = h + h * text_background_padding * 2
         text_background_im = Image.new(mode='RGBA',
                                        size=(math.ceil(text_background_width), math.ceil(text_background_height)),
                                        color=text_background_color)


### PR DESCRIPTION
# New features and improvements
- Add "avoid overlay" option to generation captioned

Example:

```
from pynter.pynter import generate_captioned
font_path = './Roboto/Roboto-Regular.ttf'
image_path = './image.jpg'
im = generate_captioned(
        'China lands rover on Mars'.upper(),
        image_path=image_path,
        size=(1080, 1150),
        image_mode=ImageMode.NOT_OVERLAY,
        font_path=str(font_path),
        text_background_color=(255, 255, 255, 255),
        color=(0, 0, 0, 255),
        text_background_mode=TextBackgroundMode.ATTACH_TO_TOP,
        text_min_height=0.3,
        top_margin=0.05,
        bottom_margin=None,
        filter_color=(0, 0, 0, 40),
        left_margin=0.1,
        right_margin=0.1,
)
im.show()
im.convert('RGB').save('drawn_image.jpg')
```

# Breaking changes
None

# Dependencies
None

# Bug fixes
None
